### PR TITLE
Add token provider for JSON metadata provider

### DIFF
--- a/Jellyfin.Plugin.AppleMusic/MetadataSources/Json/ApiClient/BaseHttpClient.cs
+++ b/Jellyfin.Plugin.AppleMusic/MetadataSources/Json/ApiClient/BaseHttpClient.cs
@@ -37,6 +37,13 @@ public class BaseHttpClient : IHttpClient
     /// <inheritdoc />
     public async Task<T?> GetAsync<T>(string url, Dictionary<string, string>? headers = null, CancellationToken cancellationToken = default)
     {
+        var content = await GetStringAsync(url, headers, cancellationToken);
+        return JsonConvert.DeserializeObject<T>(content, SerializerSettings);
+    }
+
+    /// <inheritdoc />
+    public async Task<string> GetStringAsync(string url, Dictionary<string, string>? headers = null, CancellationToken cancellationToken = default)
+    {
         using var request = new HttpRequestMessage(HttpMethod.Get, url);
 
         if (headers is not null)
@@ -49,7 +56,6 @@ public class BaseHttpClient : IHttpClient
 
         using var response = await _httpClient.SendAsync(request, cancellationToken);
         response.EnsureSuccessStatusCode();
-        var content = await response.Content.ReadAsStringAsync(cancellationToken);
-        return JsonConvert.DeserializeObject<T>(content, SerializerSettings);
+        return await response.Content.ReadAsStringAsync(cancellationToken);
     }
 }

--- a/Jellyfin.Plugin.AppleMusic/MetadataSources/Json/ApiClient/DefaultApiClient.cs
+++ b/Jellyfin.Plugin.AppleMusic/MetadataSources/Json/ApiClient/DefaultApiClient.cs
@@ -19,20 +19,20 @@ public class DefaultApiClient
     private const string Origin = "https://music.apple.com";
     private const string Referer = "https://music.apple.com/";
 
-    // TODO: Dynamic fetch & automatic refresh
-    private const string Jwt = "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6IldlYlBsYXlLaWQifQ.eyJpc3MiOiJBTVBXZWJQbGF5IiwiaWF0IjoxNzYyNTM4NTI0LCJleHAiOjE3Njk3OTYxMjQsInJvb3RfaHR0cHNfb3JpZ2luIjpbImFwcGxlLmNvbSJdfQ.2fpk1NEdRGBhrWjhjDJfeVWQyfa005cJYQ0Ye37GeD08vuyZvVA1xOc0JiePTEa9FLHa1HZjLd3n5F0CYUqLTw";
-
     private readonly IHttpClient _httpClient;
+    private readonly IAppleMusicTokenProvider _tokenProvider;
     private readonly ILogger _logger;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="DefaultApiClient"/> class.
     /// </summary>
     /// <param name="httpClient">Underlying HTTP client instance.</param>
+    /// <param name="tokenProvider">Bearer token provider.</param>
     /// <param name="logger">Logger instance.</param>
-    public DefaultApiClient(IHttpClient httpClient, ILogger logger)
+    public DefaultApiClient(IHttpClient httpClient, IAppleMusicTokenProvider tokenProvider, ILogger logger)
     {
         _httpClient = httpClient;
+        _tokenProvider = tokenProvider;
         _logger = logger;
     }
 
@@ -45,7 +45,7 @@ public class DefaultApiClient
     public async Task<SearchResponse> SearchAsync(SearchRequest request, CancellationToken cancellationToken)
     {
         var url = $"{SearchBaseUrl}?{request.ToQueryString()}";
-        var headers = CreateRequestHeaders();
+        var headers = await CreateRequestHeadersAsync(cancellationToken);
 
         _logger.LogDebug("Searching Apple Music API: {Url}", url);
 
@@ -62,7 +62,7 @@ public class DefaultApiClient
     public async Task<SearchResult?> GetAlbumAsync(string albumId, CancellationToken cancellationToken)
     {
         var url = $"{CatalogBaseUrl}/albums/{albumId}";
-        var headers = CreateRequestHeaders();
+        var headers = await CreateRequestHeadersAsync(cancellationToken);
 
         _logger.LogDebug("Fetching album from Apple Music API: {Url}", url);
 
@@ -79,7 +79,7 @@ public class DefaultApiClient
     public async Task<SearchResult?> GetArtistAsync(string artistId, CancellationToken cancellationToken)
     {
         var url = $"{CatalogBaseUrl}/artists/{artistId}";
-        var headers = CreateRequestHeaders();
+        var headers = await CreateRequestHeadersAsync(cancellationToken);
 
         _logger.LogDebug("Fetching artist from Apple Music API: {Url}", url);
 
@@ -87,11 +87,12 @@ public class DefaultApiClient
         return response?.Data?.FirstOrDefault();
     }
 
-    private static Dictionary<string, string> CreateRequestHeaders()
+    private async Task<Dictionary<string, string>> CreateRequestHeadersAsync(CancellationToken cancellationToken)
     {
+        var token = await _tokenProvider.GetTokenAsync(cancellationToken);
         return new Dictionary<string, string>
         {
-            { "Authorization", $"Bearer {Jwt}" },
+            { "Authorization", $"Bearer {token}" },
             { "Origin", Origin },
             { "Referer", Referer },
         };

--- a/Jellyfin.Plugin.AppleMusic/MetadataSources/Json/ApiClient/IAppleMusicTokenProvider.cs
+++ b/Jellyfin.Plugin.AppleMusic/MetadataSources/Json/ApiClient/IAppleMusicTokenProvider.cs
@@ -1,0 +1,17 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Jellyfin.Plugin.AppleMusic.MetadataSources.Json.ApiClient;
+
+/// <summary>
+/// Provides a bearer token for authenticating against the Apple Music JSON API.
+/// </summary>
+public interface IAppleMusicTokenProvider
+{
+    /// <summary>
+    /// Gets a valid Apple Music bearer token, fetching or refreshing it as needed.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A valid bearer token.</returns>
+    Task<string> GetTokenAsync(CancellationToken cancellationToken);
+}

--- a/Jellyfin.Plugin.AppleMusic/MetadataSources/Json/ApiClient/IHttpClient.cs
+++ b/Jellyfin.Plugin.AppleMusic/MetadataSources/Json/ApiClient/IHttpClient.cs
@@ -18,4 +18,13 @@ public interface IHttpClient
     /// <typeparam name="T">Response type.</typeparam>
     /// <returns>Deserialized response, or null on error.</returns>
     Task<T?> GetAsync<T>(string url, Dictionary<string, string>? headers = null, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Send a GET request and return the raw response body.
+    /// </summary>
+    /// <param name="url">Request URL.</param>
+    /// <param name="headers">Optional headers to include in the request.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The response body as a string.</returns>
+    Task<string> GetStringAsync(string url, Dictionary<string, string>? headers = null, CancellationToken cancellationToken = default);
 }

--- a/Jellyfin.Plugin.AppleMusic/MetadataSources/Json/ApiClient/WebPlayTokenProvider.cs
+++ b/Jellyfin.Plugin.AppleMusic/MetadataSources/Json/ApiClient/WebPlayTokenProvider.cs
@@ -1,0 +1,200 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Plugin.AppleMusic.MetadataSources.Json.ApiClient;
+
+/// <summary>
+/// Provides the Apple Music web player bearer token.
+/// The token is scraped from the Apple Music website's script bundle and cached
+/// until shortly before it expires, at which point the next request re-fetches it.
+/// </summary>
+public partial class WebPlayTokenProvider : IAppleMusicTokenProvider, IDisposable
+{
+    private const string HomePageUrl = "https://music.apple.com/";
+    private const string AssetsBaseUrl = "https://music.apple.com";
+    private const string WebPlayKeyId = "WebPlayKid";
+    private const string UserAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
+    private static readonly TimeSpan _refreshMargin = TimeSpan.FromHours(24);
+
+    private readonly IHttpClient _httpClient;
+    private readonly ILogger _logger;
+    private readonly SemaphoreSlim _refreshLock = new(1, 1);
+
+    private string? _token;
+    private DateTimeOffset _expiresAt = DateTimeOffset.MinValue;
+    private bool _isDisposed;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="WebPlayTokenProvider"/> class.
+    /// </summary>
+    /// <param name="httpClient">Underlying HTTP client.</param>
+    /// <param name="logger">Logger.</param>
+    public WebPlayTokenProvider(IHttpClient httpClient, ILogger logger)
+    {
+        _httpClient = httpClient;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task<string> GetTokenAsync(CancellationToken cancellationToken)
+    {
+        if (_token is not null && IsTokenValid())
+        {
+            return _token;
+        }
+
+        await _refreshLock.WaitAsync(cancellationToken);
+        try
+        {
+            if (_token is not null && IsTokenValid())
+            {
+                return _token;
+            }
+
+            await RefreshAsync(cancellationToken);
+            return _token!;
+        }
+        finally
+        {
+            _refreshLock.Release();
+        }
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+
+    /// <summary>
+    /// Releases the resources used by this instance.
+    /// </summary>
+    /// <param name="disposing">Whether to release managed resources.</param>
+    protected virtual void Dispose(bool disposing)
+    {
+        if (_isDisposed)
+        {
+            return;
+        }
+
+        if (disposing)
+        {
+            _refreshLock.Dispose();
+        }
+
+        _isDisposed = true;
+    }
+
+    private bool IsTokenValid()
+    {
+        return DateTimeOffset.UtcNow < _expiresAt - _refreshMargin;
+    }
+
+    private async Task RefreshAsync(CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Fetching Apple Music web player token");
+
+        var headers = new Dictionary<string, string> { { "User-Agent", UserAgent } };
+
+        var html = await _httpClient.GetStringAsync(HomePageUrl, headers, cancellationToken);
+        var bundleMatch = BundleRegex().Match(html);
+        if (!bundleMatch.Success)
+        {
+            _logger.LogError("Could not locate the Apple Music web player script bundle in the page");
+            throw new InvalidOperationException("Failed to locate the Apple Music web player script bundle.");
+        }
+
+        var bundleUrl = AssetsBaseUrl + bundleMatch.Value;
+        var bundle = await _httpClient.GetStringAsync(bundleUrl, headers, cancellationToken);
+
+        var token = ExtractWebPlayToken(bundle);
+        if (token is null)
+        {
+            _logger.LogError("Could not extract the Apple Music web player token from bundle {BundleUrl}", bundleUrl);
+            throw new InvalidOperationException("Failed to extract the Apple Music web player token from the script bundle.");
+        }
+
+        _token = token;
+        _expiresAt = ReadExpiry(token);
+        _logger.LogInformation("Apple Music web player token refreshed, expires at {ExpiresAt}", _expiresAt);
+    }
+
+    private static string? ExtractWebPlayToken(string bundle)
+    {
+        foreach (Match match in JwtRegex().Matches(bundle))
+        {
+            var token = match.Value;
+            if (GetHeaderKeyId(token) == WebPlayKeyId)
+            {
+                return token;
+            }
+        }
+
+        return null;
+    }
+
+    private static string? GetHeaderKeyId(string token)
+    {
+        var header = DecodeSegment(token, 0);
+        if (header is null)
+        {
+            return null;
+        }
+
+        using var document = JsonDocument.Parse(header);
+        return document.RootElement.TryGetProperty("kid", out var kid) ? kid.GetString() : null;
+    }
+
+    private static DateTimeOffset ReadExpiry(string token)
+    {
+        var payload = DecodeSegment(token, 1);
+        if (payload is not null)
+        {
+            using var document = JsonDocument.Parse(payload);
+            if (document.RootElement.TryGetProperty("exp", out var exp) && exp.TryGetInt64(out var seconds))
+            {
+                return DateTimeOffset.FromUnixTimeSeconds(seconds);
+            }
+        }
+
+        // Without a readable expiry, treat the token as immediately stale so the next
+        // request re-fetches rather than trusting an unbounded token.
+        return DateTimeOffset.MinValue;
+    }
+
+    private static string? DecodeSegment(string token, int index)
+    {
+        var parts = token.Split('.');
+        if (parts.Length <= index)
+        {
+            return null;
+        }
+
+        // JWTs use base64url, which swaps '+' and '/' for '-' and '_'
+        // Convert them back for Convert.FromBase64String
+        var value = parts[index].Replace('-', '+').Replace('_', '/');
+
+        // base64 requires the length to be a multiple of 4, so restore padding if necessary
+        var padding = (4 - (value.Length % 4)) % 4;
+        if (padding > 0)
+        {
+            value = value.PadRight(value.Length + padding, '=');
+        }
+
+        var bytes = Convert.FromBase64String(value);
+        return Encoding.UTF8.GetString(bytes);
+    }
+
+    [GeneratedRegex(@"/assets/index~[A-Za-z0-9]+\.js")]
+    private static partial Regex BundleRegex();
+
+    [GeneratedRegex(@"eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+")]
+    private static partial Regex JwtRegex();
+}

--- a/Jellyfin.Plugin.AppleMusic/MetadataSources/MetadataSourceFactory.cs
+++ b/Jellyfin.Plugin.AppleMusic/MetadataSources/MetadataSourceFactory.cs
@@ -36,7 +36,8 @@ public static class MetadataSourceFactory
     {
         var httpClient = httpClientFactory.CreateClient(NamedClient.Default);
         var baseHttpClient = new BaseHttpClient(httpClient, loggerFactory.CreateLogger<BaseHttpClient>());
-        var apiClient = new DefaultApiClient(baseHttpClient, loggerFactory.CreateLogger<DefaultApiClient>());
+        var tokenProvider = new WebPlayTokenProvider(baseHttpClient, loggerFactory.CreateLogger<WebPlayTokenProvider>());
+        var apiClient = new DefaultApiClient(baseHttpClient, tokenProvider, loggerFactory.CreateLogger<DefaultApiClient>());
         return new JsonMetadataSource(apiClient, loggerFactory);
     }
 }

--- a/build.yaml
+++ b/build.yaml
@@ -1,7 +1,7 @@
 ---
 name: "Apple Music"
 guid: "a9f62a44-fea5-46c3-ac26-55abba29c7c8"
-version: "3.0.6.2"
+version: "3.0.7.3"
 targetAbi: "10.10.0.0"
 framework: "net8.0"
 overview: "Fetch images and metadata from Apple Music."


### PR DESCRIPTION
Automatically get JWT from the Apple Music Web DOM and use it for JSON API requests.